### PR TITLE
Improve axis labels and titles

### DIFF
--- a/examples/dxl_reacher.py
+++ b/examples/dxl_reacher.py
@@ -105,7 +105,7 @@ def plot_dxl_reacher(env, batch_size, shared_returns, plot_running):
     fig.suptitle("DXL Reacher", fontsize=14)
     ax2.set_title("Learning Curve")
     ax2.set_xlabel("Time Step")
-    ax2.set_ylabel("Average Reward")
+    ax2.set_ylabel("Average Returns")
     count = 0
 
     old_size = len(shared_returns['episodic_returns'])

--- a/examples/dxl_tracker.py
+++ b/examples/dxl_tracker.py
@@ -104,7 +104,7 @@ def plot_dxl_tracker(env, batch_size, shared_returns, plot_running):
     fig.suptitle("DXL Tracker", fontsize=14)
     ax2.set_title("Learning Curve")
     ax2.set_xlabel("Time Step")
-    ax2.set_ylabel("Average Reward")
+    ax2.set_ylabel("Average Returns")
     count = 0
 
     old_size = len(shared_returns['episodic_returns'])

--- a/examples/sim_double_pendulum.py
+++ b/examples/sim_double_pendulum.py
@@ -81,7 +81,7 @@ def plot_returns(env, batch_size, shared_returns, plot_running):
     fig.suptitle("Simulated Double Pendulum", fontsize=14)
     ax.set_title("Learning Curve")
     ax.set_xlabel("Time Step")
-    ax.set_ylabel("Average Reward")
+    ax.set_ylabel("Average Returns")
     count = 0
     old_size = len(shared_returns['episodic_returns'])
     returns = []


### PR DESCRIPTION
Labels and titles.

Here's what it looked like before:
![image](https://user-images.githubusercontent.com/1737560/44309810-4acc6380-a39a-11e8-881a-33b083a9d4a1.png)

And after:
![image](https://user-images.githubusercontent.com/1737560/44309902-9f241300-a39b-11e8-85c5-3ee4ca431841.png)

Another after:
![image](https://user-images.githubusercontent.com/1737560/44309815-5b7cd980-a39a-11e8-9973-a63056ce0b38.png)

Is "Time Step" the most correct label here?

The improvements are only for DXL-reacher, DXL-tracker, and sim_double_pendulum. These are the only tasks I have the hardware for.