### PR TITLE
Csherstan/dxl reacher extract communicator

### DIFF
--- a/examples/advanced/dxl_reacher.py
+++ b/examples/advanced/dxl_reacher.py
@@ -20,14 +20,16 @@ from senseact.envs.dxl.dxl_reacher_env import DxlReacher1DEnv
 from senseact.utils import tf_set_seeds, NormalizedEnv
 
 
-def main(port, id, baud):
+def main(port, id, baud, use_pyserial):
     # use fixed random state
     rand_state = np.random.RandomState(1).get_state()
     np.random.set_state(rand_state)
     tf_set_seeds(np.random.randint(1, 2 ** 31 - 1))
 
+    cycle_time = 0.04
     obs_history = 1
     comm_name = "DXL"
+    sensor_dt = 0.01
     communicator_setups = {
         comm_name: {
             'Communicator': gcomm.DXLCommunicator,
@@ -37,7 +39,7 @@ def main(port, id, baud):
                 "baudrate": baud,
                 "sensor_dt": 0.01,
                 "device_path": port,
-                "use_ctypes_driver": True
+                "use_ctypes_driver": not use_pyserial
             }
         }
     }
@@ -48,7 +50,8 @@ def main(port, id, baud):
                           actuator_name=comm_name,
                           sensor_name=comm_name,
                           obs_history=obs_history,
-                          dt=0.04,
+                          dt=cycle_time,
+                          sensor_dt=sensor_dt,
                           rllab_box=False,
                           episode_length_step=None,
                           episode_length_time=2,
@@ -192,6 +195,7 @@ if __name__ == '__main__':
     parser.add_argument("--port", type=str, default=None)
     parser.add_argument("--id", type=int, default=1)
     parser.add_argument("--baud", type=int, default=1000000)
+    parser.add_argument("--use_pyserial", action="store_true", default=False)
     args = parser.parse_args()
 
     main(**args.__dict__)

--- a/examples/advanced/dxl_reacher.py
+++ b/examples/advanced/dxl_reacher.py
@@ -20,7 +20,7 @@ from senseact.envs.dxl.dxl_reacher_env import DxlReacher1DEnv
 from senseact.utils import tf_set_seeds, NormalizedEnv
 
 
-def main(port: str, id: int, baud: int):
+def main(port, id, baud):
     # use fixed random state
     rand_state = np.random.RandomState(1).get_state()
     np.random.set_state(rand_state)
@@ -109,6 +109,7 @@ def main(port: str, id: int, baud: int):
 
     # Shutdown the environment
     env.close()
+
 
 def plot_dxl_reacher(env, batch_size, shared_returns, plot_running):
     """ Visualizes the DXL reacher task and plots episodic returns

--- a/senseact/devices/dxl/dxl_communicator.py
+++ b/senseact/devices/dxl/dxl_communicator.py
@@ -84,6 +84,10 @@ class DXLCommunicator(Communicator):
         self.max_actuation_time = 1
         self.torque = 0
 
+    def get_register_names(self):
+        read_block = dxl_mx64.MX64.subblock('version_0', 'goal_acceleration', ret_dxl_type=True)
+        return [reg.name for reg in read_block]
+
     def run(self):
         """ Override base class run method to setup dxl driver.
 

--- a/senseact/envs/dxl/dxl_reacher_env.py
+++ b/senseact/envs/dxl/dxl_reacher_env.py
@@ -29,24 +29,22 @@ class DxlReacher1DEnv(RTRLBaseEnv, gym.core.Env):
 
     def __init__(self,
                  setup='dxl_gripper_default',
-                 idn=9,
-                 baudrate=1000000,
+                 communicator_setups=None,
+                 actuator_name=None,
+                 sensor_name=None,
                  obs_history=1,
                  dt=0.01,
-                 gripper_dt=0.006,
                  rllab_box=False,
                  episode_length_step=None,
                  episode_length_time=4,
                  dof=1,
-                 max_torque_mag = 300,
+                 max_torque_mag=300,
                  control_type='torque',
                  target_type='position',
                  reset_type='zero',
                  reward_type='linear',
                  delay=0,
-                 dxl_dev_path='None',
                  max_velocity=5,
-                 use_ctypes_driver=True,
                  **kwargs
                  ):
         """ Inits DxlReacher1DEnv class with task and servo specific parameters.
@@ -54,8 +52,16 @@ class DxlReacher1DEnv(RTRLBaseEnv, gym.core.Env):
         Args:
             setup: A dictionary containing DXL reacher task specifications,
                 such as bounding box dimensions, joint angle ranges and max load.
-            idn: An integer representing the DXL ID number
-            baudrate: An integer representing a baudrate to connect at
+            communicator_setups: A dict with keys that uniquely name the communicator.
+                By default only a single communicator should be set if a single process
+                handles both sensing and actuation. The value should be another dict
+                containing
+                    'Communicator': the communicator class
+                    'num_sensor_packets': Set if this class does sensing. Should equal obs_history
+                    'kwargs': the arguments needed to instantiate the communicator
+            actuator_name: Name of the actuator interface,
+            sensor_name: Name of the sensor interface. If a single interface handles both
+                sensing and actuation then these should be the same.
             obs_history: An integer number of sensory packets concatenated
                 into a single observation vector
             dt: A float specifying duration of an environment time step
@@ -94,7 +100,7 @@ class DxlReacher1DEnv(RTRLBaseEnv, gym.core.Env):
         self.cool_down_temperature = 50
         self.obs_history = obs_history
         self.dt = dt
-        self.gripper_dt = gripper_dt
+        self.gripper_dt = dt
 
         self.max_torque_mag = np.array([max_torque_mag])
         self.max_velocity = np.array([max_velocity])
@@ -177,21 +183,12 @@ class DxlReacher1DEnv(RTRLBaseEnv, gym.core.Env):
             from rllab.envs.env_spec import EnvSpec
             self._spec = EnvSpec(self.observation_space, self.action_space)
 
-        self._comm_name = 'DxlReacher1D'
-        self._dxl_dev_path = dxl_dev_path
-        communicator_setups = {
-            self._comm_name: {
-                'Communicator': gcomm.DXLCommunicator,
-                'num_sensor_packets': obs_history,
-                'kwargs': {
-                    'idn': idn,
-                    'baudrate': baudrate,
-                    'sensor_dt': gripper_dt,
-                    'device_path': self._dxl_dev_path,
-                    'use_ctypes_driver': use_ctypes_driver,
-                }
-            }
-        }
+        self._sensor_name = sensor_name
+        self._actuator_name = actuator_name
+
+        if len(communicator_setups) == 1:
+            assert sensor_name == actuator_name
+
         super(DxlReacher1DEnv, self).__init__(
             communicator_setups=communicator_setups,
             action_dim=1,
@@ -200,8 +197,7 @@ class DxlReacher1DEnv(RTRLBaseEnv, gym.core.Env):
             **kwargs
         )
 
-        read_block = dxl_mx64.MX64.subblock('version_0', 'goal_acceleration', ret_dxl_type=use_ctypes_driver)
-        self.regnames = [reg.name for reg in read_block]
+        self.regnames = self._sensor_comms[self._sensor_name].get_register_names()
         self.reg_index = dict(zip(self.regnames, range(len(self.regnames))))
 
         self.episode_steps = 0
@@ -226,7 +222,7 @@ class DxlReacher1DEnv(RTRLBaseEnv, gym.core.Env):
         # Default initialization
         target_pos = np.random.uniform(low=self.angle_low, high=self.angle_high)
         self.pos_range = self.angle_high - self.angle_low
-        self.reset_pos_center = self.angle_high - (self.pos_range//2)
+        self.reset_pos_center = self.angle_high - (self.pos_range // 2)
         self.action_range = self.action_high - self.action_low
 
         self._reward_ = Value('d', 0.0)
@@ -237,12 +233,12 @@ class DxlReacher1DEnv(RTRLBaseEnv, gym.core.Env):
         self._action_history = deque([0] * (self.obs_history + 1), self.obs_history + 1)
 
         # Tell the dxl to do nothing (overwritting previous command)
-        self.nothing_packet = np.zeros(self._actuator_comms[self._comm_name].actuator_buffer.array_len)
+        self.nothing_packet = np.zeros(self._actuator_comms[self._actuator_name].actuator_buffer.array_len)
 
         # PID control gains for reset
-        self.kp = 161.1444 # Proportional gain
-        self.ki = 0        # Integral gain
-        self.kd = 0        # Derivative gain
+        self.kp = 161.1444  # Proportional gain
+        self.ki = 0  # Integral gain
+        self.kd = 0  # Derivative gain
 
     def _reset_(self):
         """ Resets the environment episode.
@@ -266,9 +262,9 @@ class DxlReacher1DEnv(RTRLBaseEnv, gym.core.Env):
         # Once in the correct regime, the `present_pos` values can be trusted
         start_time = time.time()
         while time.time() - start_time < 5:
-            if self._sensor_comms[self._comm_name].sensor_buffer.updated():
+            if self._sensor_comms[self._sensor_name].sensor_buffer.updated():
                 sensor_window, timestamp_window, index_window = self._sensor_comms[
-                    self._comm_name].sensor_buffer.read_update(1)
+                    self._sensor_name].sensor_buffer.read_update(1)
                 present_pos = sensor_window[0][self.reg_index['present_pos']]
                 current_temperature = sensor_window[0][self.reg_index['temperature']]
 
@@ -277,18 +273,19 @@ class DxlReacher1DEnv(RTRLBaseEnv, gym.core.Env):
                     time.sleep(10)
 
                 error = self._reset_pos_.value - present_pos
-                if abs(error) > 0.017: # ~1 deg
-                    integral = integral + (error*self.gripper_dt)
-                    derivative = (error - error_prior)/self.gripper_dt
-                    action = self.kp*error + self.ki*integral + self.kd*derivative
+                if abs(error) > 0.017:  # ~1 deg
+                    integral = integral + (error * self.gripper_dt)
+                    derivative = (error - error_prior) / self.gripper_dt
+                    action = self.kp * error + self.ki * integral + self.kd * derivative
                     error_prior = error
                 else:
+                    print("Reset good.")
                     break
 
-                self._actuator_comms[self._comm_name].actuator_buffer.write(action)
+                self._actuator_comms[self._actuator_name].actuator_buffer.write(action)
                 time.sleep(0.001)
 
-        self._actuator_comms[self._comm_name].actuator_buffer.write(0)
+        self._actuator_comms[self._actuator_name].actuator_buffer.write(0)
         self.episode_steps = 0
         rand_state_array_type, rand_state_array_size, rand_state_array = utils.get_random_state_array(
             self._rand_obj_.get_state()
@@ -296,7 +293,6 @@ class DxlReacher1DEnv(RTRLBaseEnv, gym.core.Env):
         np.copyto(self._shared_rstate_array_, np.frombuffer(rand_state_array, dtype=rand_state_array_type))
         time.sleep(0.1)  # Give the shared buffer time to get updated and prevent false episode done conditions
         print("Reset done. Gripper pos: {}".format(present_pos))
-
 
     def _compute_sensation_(self, name, sensor_window, timestamp_window, index_window):
         """ Creates and saves an observation vector based on sensory data.
@@ -332,7 +328,8 @@ class DxlReacher1DEnv(RTRLBaseEnv, gym.core.Env):
         self._present_speed_ = np.array(
             [sensor_window[i][self.reg_index['present_speed']] for i in range(self.obs_history)])
         self._current_ = np.array([sensor_window[i][self.reg_index['current']] for i in range(self.obs_history)])
-        self._temperature_ = np.array([sensor_window[i][self.reg_index['temperature']] for i in range(self.obs_history)])
+        self._temperature_ = np.array(
+            [sensor_window[i][self.reg_index['temperature']] for i in range(self.obs_history)])
 
         self._reward_.value = self._compute_reward()
         done = [0]
@@ -368,14 +365,14 @@ class DxlReacher1DEnv(RTRLBaseEnv, gym.core.Env):
         """
         if self._temperature_[-1] < self.max_temperature:
             if self._present_pos_[-1] < self.angle_low:
-                self._actuation_packet_[self._comm_name] = self.max_torque_mag//2
+                action = self.max_torque_mag // 2
             elif self._present_pos_[-1] > self.angle_high:
-                self._actuation_packet_[self._comm_name] = -self.max_torque_mag//2
-            else:
-                self._actuation_packet_[self._comm_name] = action
+                action = -self.max_torque_mag // 2
+
+            self._actuation_packet_[self._actuator_name] = action
             self._action_history.append(action)
         else:
-            self._actuator_comms[self._comm_name].actuator_buffer.write(self.nothing_packet)
+            self._actuator_comms[self._actuator_name].actuator_buffer.write(self.nothing_packet)
             raise Exception('Operating temperature of the dynamixel device exceeded {} \n'
                             'Use the device once it cools down!'.format(self.max_temperature))
 
@@ -392,7 +389,7 @@ class DxlReacher1DEnv(RTRLBaseEnv, gym.core.Env):
             goal_pos = self._target_pos_.value
             present_pos = self._present_pos_
             reward -= abs(goal_pos - present_pos[-1])
-        reward *= self.dt/0.04
+        reward *= self.dt / 0.04
         return np.array([reward])
 
     def _check_done(self, env_done):
@@ -406,7 +403,7 @@ class DxlReacher1DEnv(RTRLBaseEnv, gym.core.Env):
         """
         self.episode_steps += 1
         if self.episode_steps >= self.episode_length_step or env_done:
-            self._actuator_comms[self._comm_name].actuator_buffer.write(self.nothing_packet)
+            self._actuator_comms[self._actuator_name].actuator_buffer.write(self.nothing_packet)
             done = True
         else:
             done = False
@@ -430,7 +427,7 @@ class DxlReacher1DEnv(RTRLBaseEnv, gym.core.Env):
         return float((angle - self.angle_low)) / self.pos_range
 
     def scale_action(self, action):
-        return (2*(action - self.action_low)/ self.action_range) - 1.
+        return (2 * (action - self.action_low) / self.action_range) - 1.
 
     def terminate(self):
         super(DxlReacher1DEnv, self).close()


### PR DESCRIPTION
I have extracted the communicator from the DXLReacher1DEnv. Communicators are now specified outside of this class and passed in. I suggest that this should be done with all the envs.

Also, I added a method to DXLCommunicator get_register_names. This operation was previously done inside the environment, but should be done inside the communicator itself.

Additionally, I changed gripper_dt to sensor_dt, since this represents the rate at which the sensation buffer is updated. This is only used for PID control when resetting the motor position in _reset_. I would actually suggest we drop this PID control altogether and instead put a method on any dynamixel communicator to move to a selected position. 