### PR TITLE
pulling in check for readiness

### DIFF
--- a/senseact/communicator.py
+++ b/senseact/communicator.py
@@ -47,7 +47,7 @@ class Communicator(Process):
             from the buffer by _actuator_handler
     """
 
-    def __init__(self, sensor_args, actuator_args, use_sensor=True, use_actuator=True):
+    def __init__(self, sensor_args, actuator_args, use_sensor=True, use_actuator=True, start_timeout=1.0):
         """Inits communicator class with device-specific sensor and actuation arguments.
 
         Args:
@@ -66,6 +66,8 @@ class Communicator(Process):
                 sensory data
             use_actuator: a boolean, indicating whether communicator will transfer
                 actuation data (e.g. video cameras may not have actuations)
+            start_up_time: How long to wait for start up. If the communicator does not start up in this time then
+                an exception will be thrown by the environment.
         """
         super(Communicator, self).__init__()
         self.use_sensor = use_sensor
@@ -75,6 +77,7 @@ class Communicator(Process):
         self._actuator_thread = None
         self._sensor_running = False
         self._actuator_running = False
+        self.start_timeout = start_timeout
         self._ready = Event()
         if self.use_sensor:
             self.sensor_buffer = SharedBuffer(**sensor_args)
@@ -108,7 +111,7 @@ class Communicator(Process):
                 return
 
             if (self._sensor_thread is not None and not self._sensor_thread.is_alive()) or \
-               (self._actuator_thread is not None and not self._actuator_thread.is_alive()):
+                    (self._actuator_thread is not None and not self._actuator_thread.is_alive()):
                 logging.error("Sensor/Actuator thread has exited, closing communicator.")
                 self._close()
                 return
@@ -164,4 +167,3 @@ class Communicator(Process):
             self._sensor_thread.join()
         if self._actuator_thread is not None:
             self._actuator_thread.join()
-

--- a/senseact/communicator.py
+++ b/senseact/communicator.py
@@ -9,7 +9,7 @@ import os
 import signal
 
 from threading import Thread
-from multiprocessing import Process
+from multiprocessing import Process, Event
 
 from senseact.sharedbuffer import SharedBuffer
 
@@ -75,11 +75,15 @@ class Communicator(Process):
         self._actuator_thread = None
         self._sensor_running = False
         self._actuator_running = False
+        self._ready = Event()
         if self.use_sensor:
             self.sensor_buffer = SharedBuffer(**sensor_args)
 
         if self.use_actuator:
             self.actuator_buffer = SharedBuffer(**actuator_args)
+
+    def is_ready(self):
+        return self._ready.is_set()
 
     def run(self):
         """Starts sensor and actuator related threads/processes if they exist."""
@@ -92,6 +96,8 @@ class Communicator(Process):
 
         if self.use_actuator:
             self._actuator_start()
+
+        self._ready.set()
 
         while self._sensor_running or self._actuator_running:
             # if parent pid is no longer the same (1 on Linux if re-parented to init), then

--- a/senseact/devices/create2/create2_communicator.py
+++ b/senseact/devices/create2/create2_communicator.py
@@ -14,8 +14,9 @@ from senseact.sharedbuffer import SharedBuffer
 
 class Create2Communicator(Communicator):
     """The class implements communicator for Create2 device."""
+
     def __init__(self, sensor_packet_ids, opcodes, port='/dev/ttyUSB0', baudrate=115200,
-                 buffer_len=SharedBuffer.DEFAULT_BUFFER_LEN):
+                 buffer_len=SharedBuffer.DEFAULT_BUFFER_LEN, start_timeout=10.0):
         """Inits the communicator object with device-specific parameters.
 
         Args:
@@ -48,13 +49,14 @@ class Create2Communicator(Communicator):
             max_params = max(max_params, len(self._create2.get_op_params(opcode)))
 
         actuator_args = {'buffer_len': buffer_len,
-                         'array_len': 1 + max_params,     # add one for opcode itself
+                         'array_len': 1 + max_params,  # add one for opcode itself
                          'array_type': 'i',
                          'np_array_type': 'i',
                          }
 
         super(Create2Communicator, self).__init__(use_sensor=True, use_actuator=True,
-                                                  sensor_args=sensor_args, actuator_args=actuator_args)
+                                                  sensor_args=sensor_args, actuator_args=actuator_args,
+                                                  start_timeout=start_timeout)
 
     def run(self):
         """Method called by Python when the communicator process is started."""

--- a/senseact/devices/dxl/dxl_communicator.py
+++ b/senseact/devices/dxl/dxl_communicator.py
@@ -3,14 +3,14 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-import time
 import signal
-
+import time
 from math import pi
 from threading import Lock
-from senseact.sharedbuffer import SharedBuffer
+
 from senseact.communicator import Communicator
 from senseact.devices.dxl import dxl_mx64
+from senseact.sharedbuffer import SharedBuffer
 
 
 class DXLCommunicator(Communicator):
@@ -27,6 +27,7 @@ class DXLCommunicator(Communicator):
                  sensor_dt=0.006,
                  device_path='None',
                  use_ctypes_driver=True,
+                 start_timeout=1.0
                  ):
         """ Inits DXLCommunicator class with device and task-specific parameters.
 
@@ -73,7 +74,8 @@ class DXLCommunicator(Communicator):
         super(DXLCommunicator, self).__init__(use_sensor=True,
                                               use_actuator=True,
                                               sensor_args=sensor_args,
-                                              actuator_args=actuator_args)
+                                              actuator_args=actuator_args,
+                                              start_timeout=start_timeout)
 
         self.just_read = 0
         self.just_read_lock = Lock()

--- a/senseact/devices/ur/ur_communicator.py
+++ b/senseact/devices/ur/ur_communicator.py
@@ -11,6 +11,7 @@ from senseact.devices.ur import ur_utils
 from senseact.sharedbuffer import SharedBuffer
 from threading import Lock
 
+
 class URCommunicator(Communicator):
     """Communicator class for UR5 robot.
 
@@ -29,8 +30,9 @@ class URCommunicator(Communicator):
     def __init__(self, host,
                  actuation_sync_period=True,
                  disable_nagle_algorithm=True,
-                 speedj_timeout = 0.5,
-                 buffer_len=None
+                 speedj_timeout=0.5,
+                 buffer_len=None,
+                 start_timeout=1.0
                  ):
         """Inits URCommunicator class with device- and task-specific parameters.
 
@@ -71,7 +73,8 @@ class URCommunicator(Communicator):
         super(URCommunicator, self).__init__(use_sensor=True,
                                              use_actuator=True,
                                              sensor_args=sensor_args,
-                                             actuator_args=actuator_args)
+                                             actuator_args=actuator_args,
+                                             start_timeout=start_timeout)
 
         # make connections
         self._sock = URCommunicator.make_connection(
@@ -84,7 +87,7 @@ class URCommunicator(Communicator):
         self._dashboard_sock = URCommunicator.make_connection(
             host=self._host,
             port=ur_utils.DASHBOARD_SERVER_PORT,
-            disable_nagle_algorithm = self._disable_nagle_algorithm
+            disable_nagle_algorithm=self._disable_nagle_algorithm
         )
         time.sleep(0.5)
 
@@ -131,7 +134,7 @@ class URCommunicator(Communicator):
             else:
                 print('', e, ': Lost socket to UR, going into reconnect loop')
             self._stop = True
-            time.sleep(ur_utils.ACTUATOR_DT*2)  # to let _actuator_handler thread return
+            time.sleep(ur_utils.ACTUATOR_DT * 2)  # to let _actuator_handler thread return
             self._sock.close()
             self._dashboard_sock.close()
             self._sock = self.make_connection(self._host,
@@ -140,7 +143,7 @@ class URCommunicator(Communicator):
                                               )
             self._dashboard_sock = self.make_connection(self._host,
                                                         ur_utils.DASHBOARD_SERVER_PORT,
-                                                        disable_nagle_algorithm = self._disable_nagle_algorithm
+                                                        disable_nagle_algorithm=self._disable_nagle_algorithm
                                                         )
             self._stop = False
         except Exception as e:

--- a/senseact/envs/create2/create2_mover_env.py
+++ b/senseact/envs/create2/create2_mover_env.py
@@ -30,7 +30,7 @@ class Create2MoverEnv(RTRLBaseEnv, gym.Env):
     """
 
     def __init__(self, episode_length_time, port='/dev/ttyUSB0', obs_history=1, dt=0.015,
-                 auto_unwind=True, rllab_box=False, **kwargs):
+                 auto_unwind=True, rllab_box=False, start_timeout=None, **kwargs):
         """Constructor of the environment.
 
         Args:
@@ -40,6 +40,10 @@ class Create2MoverEnv(RTRLBaseEnv, gym.Env):
             dt:                  the cycle time in seconds
             auto_unwind:         boolean of whether we want to execute the auto cable-unwind code
             rllab_box:           whether we are using rllab algorithm or not
+            start_timeout: The amount of time (in seconds) to wait for all communicators to start.
+                            If set to None (default) the longest timeout values set by each communicator will be used. If set to
+                            -1 then the environment will wait indefinitely. If set >= 0 then the timeout value provided will
+                            take precedence over the start_timeout values set on the communicators.
             **kwargs:            the remaining arguments passed to the base class
         """
         self._obs_history = obs_history
@@ -120,14 +124,15 @@ class Create2MoverEnv(RTRLBaseEnv, gym.Env):
                                                             'opcodes': [main_opcode] + extra_opcodes,
                                                             'port': port,
                                                             'buffer_len': 2 * buffer_len,
-                                                           }
-                                                }
-                              }
+                                                            }
+                                                 }
+                               }
 
         super(Create2MoverEnv, self).__init__(communicator_setups=communicator_setups,
                                               action_dim=len(self._action_space.low),
                                               observation_dim=len(self._observation_space.low),
                                               dt=dt,
+                                              start_timeout=start_timeout,
                                               **kwargs)
 
     def _compute_sensation_(self, name, sensor_window, timestamp_window, index_window):
@@ -294,7 +299,7 @@ class Create2MoverEnv(RTRLBaseEnv, gym.Env):
             distance_reward += distance
 
         reward = 0
-        reward += distance_reward   # tiny reward for forward progress
+        reward += distance_reward  # tiny reward for forward progress
 
         # multiply by a constant
         reward *= 0.15

--- a/senseact/rtrl_base_env.py
+++ b/senseact/rtrl_base_env.py
@@ -37,6 +37,7 @@ class RTRLBaseEnv(object):
                  sleep_time=0.0001,
                  busy_loop=True,
                  random_state=None,
+                 start_timeout=None,
                  **kwargs
                  ):
 
@@ -63,6 +64,10 @@ class RTRLBaseEnv(object):
                 numpy.random.RandomState().get_state(). This is to ensure
                 reproducibility by reusing the same random state externally from
                 an experiment script.
+            start_timeout: The amount of time (in seconds) to wait for all communicators to start.
+                If set to None (default) the longest timeout values set by each communicator will be used. If set to
+                -1 then the environment will wait indefinitely. If set >= 0 then the timeout value provided will
+                take precedence over the start_timeout values set on the communicators.
             sleep_time: a float representing lower bound on sleep() function
                 time resolution provided by OS. For linux based OSes the
                 resolution is typically ~0.001s, for Windows based OSes its ~0.01s.
@@ -77,6 +82,7 @@ class RTRLBaseEnv(object):
         self._dt_tol = dt_tol
         self._sleep_time = sleep_time
         self._busy_loop = busy_loop
+        self.start_timeout = start_timeout
 
         # create random object based on passed random_state tuple
         self._rand_obj_ = np.random.RandomState()
@@ -159,18 +165,26 @@ class RTRLBaseEnv(object):
         self._running = True
 
         waiting_for = []
+        timeout = 0
         # Start the communicator process
         for key, comm in self._all_comms.items():
+            timeout = max(timeout, comm.start_timeout)
             comm.start()
             waiting_for.append((key, comm))
 
-        timeout = 5
+        """
+        If self.start_timeout is -1 then we'll wait indefinitely.
+        If self.start_timeout is None then we use the longest start_timeout specified by all comms.
+        If self.start_timeout is >= 0 then that is the value we will use.
+        """
+        timeout = timeout if self.start_timeout is None else self.start_timeout
+
         start_time = time.time()
         while len(waiting_for) > 0:
             time.sleep(0.5)  # let the communicator buffer have some packets
             # We're going to wait until the communicators are all online.
             waiting_for = [kc for kc in itertools.filterfalse(lambda key_comm: key_comm[1].is_ready(), waiting_for)]
-            if time.time() - start_time > timeout:
+            if (timeout >= 0) and (time.time() - start_time > timeout):
                 raise TimeoutError(f"Timed out waiting for communicators: {[key for key, comm in waiting_for]}")
 
         self._new_obs_time = time.time()


### PR DESCRIPTION
Added in a way to check that all communicators are active before the environment starts. Because the RTRLBaseEnv has its own polling threads with the buffer in between it can happily provide empty data from the buffer without the env being any wiser. The learning alg won't work, robots won't move, etc. This way when the communicator times out it can let the user know that it is the communicator that's the problem.

This has come in handy when using the ROS based communicators.

I have only tested this on the DXL motors, not UR5 or Create.